### PR TITLE
fix: repo url already contains github domain

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -111,7 +111,7 @@ function checkPreconditions() {
       exec(`git push -u origin ${featureBranch}`)
     }
 
-    prUrls.push(`https://github.com/${repo}/compare/${target}...${featureBranch}`)
+    prUrls.push(`https:${repo}/compare/${target}...${featureBranch}`)
   })
 
   console.log('\n\n')


### PR DESCRIPTION
### Issue link
n/a

### 📖  Description
This pull request removes duplicate `//github/` from the generated PR link.
it was generating links like this: https://github.com///github.com/PitcherAG/sandoz-precall-windows/compare/qa...deploy/CAL-4322_to_qa